### PR TITLE
feat: add deck transformer mvp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+app/svc/data/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# chatgpt

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# chatgpt
+# Deck Transformer Monorepo
+
+This repository provides a minimal MVP that restyles a source deck (PPTX or PDF) into a provided PPTX brand template. It includes:
+
+- **/app/svc** – FastAPI service implementing template/source ingestion, planning, layout swapping, execution and job tracking.
+- **/app/web** – Next.js 14 client with basic upload and export flow.
+- **/app/infra** – `docker-compose` setup for local development.
+
+## Quick start
+
+```bash
+# install python deps
+pip install -r app/svc/requirements.txt
+# generate fixtures (optional)
+python app/svc/fixtures/generate.py
+# run service
+uvicorn app/svc/main:app --reload
+```
+
+In another terminal:
+
+```bash
+cd app/web
+npm install
+npm run dev
+```
+
+The web app expects the service at `NEXT_PUBLIC_SVC_URL` (default `http://localhost:8000`).
+
+For Docker based dev:
+
+```bash
+cd app/infra
+docker-compose up --build
+```
+
+## Testing
+
+```bash
+PYTHONPATH=app/svc pytest app/svc/tests
+```
+
+## Limitations & next steps
+
+- Text overflow, image placement and table splitting use very rough heuristics.
+- PDF ingestion offers only basic text extraction; reliability is medium/low and OCR is not yet wired.
+- Execution copies simple text and ignores advanced formatting, animations or charts.
+- Authentication, AV scanning and persistent object storage are out of scope for this MVP.

--- a/app/infra/docker-compose.yaml
+++ b/app/infra/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "3.9"
+services:
+  svc:
+    build: ../svc
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
+    volumes:
+      - ../svc:/app
+    ports:
+      - "8000:8000"
+  web:
+    build: ../web
+    command: npm run dev
+    volumes:
+      - ../web:/app
+    environment:
+      - NEXT_PUBLIC_SVC_URL=http://localhost:8000
+    ports:
+      - "3000:3000"

--- a/app/svc/Dockerfile
+++ b/app/svc/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/svc/db.py
+++ b/app/svc/db.py
@@ -1,0 +1,17 @@
+import sqlite3
+from pathlib import Path
+
+data_dir = Path(__file__).parent / 'data'
+DB_PATH = data_dir / 'svc.db'
+
+
+def init_db():
+    data_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute('CREATE TABLE IF NOT EXISTS templates (id TEXT PRIMARY KEY, meta TEXT)')
+    cur.execute('CREATE TABLE IF NOT EXISTS sources (id TEXT PRIMARY KEY, type TEXT, template_id TEXT, meta TEXT)')
+    cur.execute('CREATE TABLE IF NOT EXISTS plans (id TEXT PRIMARY KEY, template_id TEXT, source_id TEXT, data TEXT)')
+    cur.execute('CREATE TABLE IF NOT EXISTS jobs (id TEXT PRIMARY KEY, plan_id TEXT, status TEXT, artifact TEXT)')
+    conn.commit()
+    return conn

--- a/app/svc/executor.py
+++ b/app/svc/executor.py
@@ -1,0 +1,36 @@
+from pptx import Presentation
+from pathlib import Path
+from typing import Dict, Any
+
+
+def execute(plan: Dict[str, Any], template_path: Path, source_path: Path, output_path: Path):
+    tpl = Presentation(template_path)
+    src = Presentation(source_path)
+    out = Presentation(template_path)
+    out.slides._sldIdLst.clear()  # start empty
+    layouts = tpl.slide_layouts
+    for slide_plan in plan['slides']:
+        idx = slide_plan['idx']
+        layout = layouts[slide_plan['chosen_layout_id']]
+        new_slide = out.slides.add_slide(layout)
+        src_slide = src.slides[idx]
+        title_text = ''
+        body_text = []
+        for shp in src_slide.shapes:
+            if shp.has_text_frame:
+                if shp.is_placeholder and shp.placeholder_format.type==1:  # title
+                    title_text = shp.text
+                else:
+                    for p in shp.text_frame.paragraphs:
+                        body_text.append(p.text)
+        if title_text and new_slide.shapes.title:
+            new_slide.shapes.title.text = title_text
+        body_phs = [shp for shp in new_slide.shapes if shp.is_placeholder and shp.placeholder_format.type==2]
+        if body_phs:
+            tf = body_phs[0].text_frame
+            tf.clear()
+            for i,line in enumerate(body_text):
+                p = tf.add_paragraph() if i>0 else tf.paragraphs[0]
+                p.text = line
+        # TODO: handle images, tables, overflow splitting
+    out.save(output_path)

--- a/app/svc/fixtures/generate.py
+++ b/app/svc/fixtures/generate.py
@@ -1,0 +1,64 @@
+"""Generate sample fixtures for tests and manual usage."""
+from pptx import Presentation
+from pptx.util import Inches
+from pathlib import Path
+from reportlab.pdfgen import canvas
+
+DATA_DIR = Path(__file__).resolve().parent.parent / 'data' / 'fixtures'
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+def build_template(path: Path):
+    prs = Presentation()
+    prs.slide_layouts[0].name = 'Title'
+    prs.slide_layouts[1].name = 'Title and Content'
+    prs.slide_layouts[2].name = 'Section Header'
+    prs.slide_layouts[3].name = 'Two Content'
+    prs.slide_layouts[4].name = 'Content with Caption'
+    prs.save(path)
+
+
+def build_source_pptx(path: Path):
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[2])
+    slide.shapes.title.text = 'Section'
+    slide = prs.slides.add_slide(prs.slide_layouts[1])
+    slide.shapes.title.text = 'Bullets'
+    tf = slide.shapes.placeholders[1].text_frame
+    for i in range(3):
+        p = tf.add_paragraph() if i>0 else tf.paragraphs[0]
+        p.text = f'Point {i+1}'
+        p.level = 1
+    slide = prs.slides.add_slide(prs.slide_layouts[3])
+    slide.shapes.title.text = 'Two Column'
+    slide.shapes.placeholders[1].text = 'Left'
+    slide.shapes.placeholders[2].text = 'Right'
+    slide = prs.slides.add_slide(prs.slide_layouts[4])
+    slide.shapes.title.text = 'Image'
+    pic_path = DATA_DIR / 'python.png'
+    if not pic_path.exists():
+        from PIL import Image, ImageDraw
+        img = Image.new('RGB', (200,200), 'blue')
+        ImageDraw.Draw(img).text((50,90), 'IMG', fill='white')
+        img.save(pic_path)
+    slide.shapes.add_picture(str(pic_path), Inches(1), Inches(1))
+    slide = prs.slides.add_slide(prs.slide_layouts[1])
+    slide.shapes.title.text = 'Table'
+    table = slide.shapes.add_table(2,2, Inches(1), Inches(2), Inches(6), Inches(1.5)).table
+    table.cell(0,0).text = 'A'
+    table.cell(0,1).text = 'B'
+    table.cell(1,0).text = 'C'
+    table.cell(1,1).text = 'D'
+    prs.save(path)
+
+
+def build_pdf(path: Path):
+    c = canvas.Canvas(str(path))
+    for i in range(5):
+        c.drawString(72, 720, f"Page {i+1} - Sample text")
+        c.showPage()
+    c.save()
+
+if __name__ == '__main__':
+    build_template(DATA_DIR / 'brand_simple.pptx')
+    build_source_pptx(DATA_DIR / 'mini_5slide.pptx')
+    build_pdf(DATA_DIR / 'mini_pdf_5page.pdf')

--- a/app/svc/main.py
+++ b/app/svc/main.py
@@ -1,0 +1,169 @@
+import uuid
+from pathlib import Path
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import json
+
+from db import init_db
+from pptx_template import parse_template
+from source_parser import parse_pptx, parse_pdf
+from planner import plan_slides
+from executor import execute
+
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=['*'], allow_methods=['*'], allow_headers=['*'])
+
+data_dir = Path(__file__).parent / 'data'
+templates_dir = data_dir / 'templates'
+sources_dir = data_dir / 'sources'
+plans_dir = data_dir / 'plans'
+jobs_dir = data_dir / 'jobs'
+for d in [templates_dir, sources_dir, plans_dir, jobs_dir]:
+    d.mkdir(parents=True, exist_ok=True)
+
+conn = init_db()
+
+class TemplateIngestResponse(BaseModel):
+    template_id: str
+    theme_meta: dict
+    layout_catalog: list
+
+
+@app.post('/templates/ingest', response_model=TemplateIngestResponse)
+async def ingest_template(template: UploadFile = File(...)):
+    template_id = str(uuid.uuid4())
+    tpl_dir = templates_dir / template_id
+    tpl_dir.mkdir(parents=True, exist_ok=True)
+    tpl_path = tpl_dir / 'template.pptx'
+    with tpl_path.open('wb') as f:
+        f.write(await template.read())
+    meta = parse_template(tpl_path)
+    cur = conn.cursor()
+    cur.execute('INSERT INTO templates(id, meta) VALUES (?, ?)', (template_id, json.dumps(meta)))
+    conn.commit()
+    return TemplateIngestResponse(template_id=template_id, **meta)
+
+
+class SourceIngestResponse(BaseModel):
+    source_id: str
+    type: str
+    pages: list
+
+
+@app.post('/sources/ingest', response_model=SourceIngestResponse)
+async def ingest_source(template_id: str = Form(...), source: UploadFile = File(...)):
+    source_id = str(uuid.uuid4())
+    suffix = Path(source.filename).suffix.lower()
+    src_dir = sources_dir / source_id
+    src_dir.mkdir(parents=True, exist_ok=True)
+    src_path = src_dir / f'source{suffix}'
+    with src_path.open('wb') as f:
+        f.write(await source.read())
+    if suffix == '.pptx':
+        pages = parse_pptx(src_path)
+        src_type = 'pptx'
+    else:
+        pages = parse_pdf(src_path)
+        src_type = 'pdf'
+    cur = conn.cursor()
+    cur.execute('INSERT INTO sources(id, type, template_id, meta) VALUES (?,?,?,?)', (source_id, src_type, template_id, json.dumps({'pages': pages})))
+    conn.commit()
+    return SourceIngestResponse(source_id=source_id, type=src_type, pages=pages)
+
+
+class PlanRequest(BaseModel):
+    template_id: str
+    source_id: str
+
+class PlanResponse(BaseModel):
+    plan_id: str
+    slides: list
+
+
+@app.post('/transform/plan', response_model=PlanResponse)
+async def create_plan(req: PlanRequest):
+    cur = conn.cursor()
+    tpl_row = cur.execute('SELECT meta FROM templates WHERE id=?', (req.template_id,)).fetchone()
+    src_row = cur.execute('SELECT meta FROM sources WHERE id=?', (req.source_id,)).fetchone()
+    if not tpl_row or not src_row:
+        return JSONResponse(status_code=404, content={'error': 'template or source not found'})
+    template_meta = json.loads(tpl_row[0])
+    source_meta = json.loads(src_row[0])
+    slides = plan_slides(source_meta['pages'], template_meta)
+    plan_id = str(uuid.uuid4())
+    plan = {'plan_id': plan_id, 'template_id': req.template_id, 'source_id': req.source_id, 'slides': slides}
+    cur.execute('INSERT INTO plans(id, template_id, source_id, data) VALUES (?,?,?,?)', (plan_id, req.template_id, req.source_id, json.dumps(plan)))
+    conn.commit()
+    with (plans_dir / f'{plan_id}.json').open('w') as f:
+        json.dump(plan, f)
+    return PlanResponse(plan_id=plan_id, slides=slides)
+
+
+class ExecuteRequest(BaseModel):
+    plan_id: str
+
+class ExecuteResponse(BaseModel):
+    job_id: str
+
+
+@app.post('/transform/execute', response_model=ExecuteResponse)
+async def transform_execute(req: ExecuteRequest):
+    cur = conn.cursor()
+    plan_row = cur.execute('SELECT data FROM plans WHERE id=?', (req.plan_id,)).fetchone()
+    if not plan_row:
+        return JSONResponse(status_code=404, content={'error':'plan not found'})
+    plan = json.loads(plan_row[0])
+    template_path = templates_dir / plan['template_id'] / 'template.pptx'
+    src_row = cur.execute('SELECT type FROM sources WHERE id=?', (plan['source_id'],)).fetchone()
+    source_path = sources_dir / plan['source_id'] / ('source.pptx' if src_row and src_row[0]=='pptx' else 'source.pdf')
+    job_id = str(uuid.uuid4())
+    job_dir = jobs_dir / job_id
+    job_dir.mkdir(parents=True, exist_ok=True)
+    output_path = job_dir / 'output.pptx'
+    execute(plan, template_path, source_path, output_path)
+    cur.execute('INSERT INTO jobs(id, plan_id, status, artifact) VALUES (?,?,?,?)', (job_id, req.plan_id, 'done', str(output_path)))
+    conn.commit()
+    return ExecuteResponse(job_id=job_id)
+
+
+class JobResponse(BaseModel):
+    status: str
+    artifact_url: str | None = None
+    preview_pngs: list | None = None
+    report: dict | None = None
+
+
+@app.get('/jobs/{job_id}', response_model=JobResponse)
+async def get_job(job_id: str):
+    cur = conn.cursor()
+    row = cur.execute('SELECT status, artifact FROM jobs WHERE id=?', (job_id,)).fetchone()
+    if not row:
+        return JSONResponse(status_code=404, content={'error':'job not found'})
+    status, artifact = row
+    artifact_url = str(Path('data') / 'jobs' / job_id / 'output.pptx') if artifact else None
+    return JobResponse(status=status, artifact_url=artifact_url)
+
+
+class SwapRequest(BaseModel):
+    idx: int
+    layout_id: int
+
+
+@app.post('/plans/{plan_id}/swap', response_model=PlanResponse)
+async def swap_layout(plan_id: str, req: SwapRequest):
+    cur = conn.cursor()
+    row = cur.execute('SELECT data FROM plans WHERE id=?', (plan_id,)).fetchone()
+    if not row:
+        return JSONResponse(status_code=404, content={'error':'plan not found'})
+    plan = json.loads(row[0])
+    for slide in plan['slides']:
+        if slide['idx'] == req.idx:
+            slide['chosen_layout_id'] = req.layout_id
+            slide['issues'] = []
+    cur.execute('UPDATE plans SET data=? WHERE id=?', (json.dumps(plan), plan_id))
+    conn.commit()
+    with (plans_dir / f'{plan_id}.json').open('w') as f:
+        json.dump(plan, f)
+    return PlanResponse(plan_id=plan_id, slides=plan['slides'])

--- a/app/svc/planner.py
+++ b/app/svc/planner.py
@@ -1,0 +1,36 @@
+from typing import List, Dict, Any
+
+
+def score_layout(sig: Dict[str, Any], layout: Dict[str, Any], theme: Dict[str, Any]):
+    title_score = 1.0 if sig['title'] == layout['placeholders']['title'] else 0.0
+    body_slots = layout['placeholders']['bodies']
+    body_slot_score = min(1, body_slots/1)  # 1 if at least one body
+    bullets_score = min(1, sig['bullets']/8) * body_slot_score
+    columns_score = 1 if ((sig['columns']==2 and body_slots>=2) or (sig['columns']==1 and body_slots>=1)) else 0
+    image_score = min(1, sig['images']/max(1, layout['placeholders']['pictures'])) if layout['placeholders']['pictures'] else (1 if sig['images']==0 else 0)
+    table_score = 1 if sig['table'] and layout['placeholders']['table'] else 0
+    score = 0.35*title_score + 0.25*bullets_score + 0.20*columns_score + 0.15*image_score + 0.05*table_score
+    issues = []
+    overflow_penalty = 0.0
+    if sig['bullets'] > 8:
+        issues.append('overflow')
+        overflow_penalty = 0.1
+    score -= overflow_penalty
+    return score, issues
+
+
+def plan_slides(slides: List[Dict[str, Any]], template: Dict[str, Any]):
+    result = []
+    layouts = template['layout_catalog']
+    for slide in slides:
+        best = {'score': -1, 'layout_id': None, 'issues': []}
+        for layout in layouts:
+            s, issues = score_layout(slide['signature'], layout, template['theme_meta'])
+            if s > best['score']:
+                best = {'score': s, 'layout_id': layout['layout_id'], 'issues': issues}
+        if best['score'] < 0.55:
+            best['issues'].append('low_fit')
+            # fallback to first layout
+            best['layout_id'] = layouts[0]['layout_id']
+        result.append({'idx': slide['idx'], 'chosen_layout_id': best['layout_id'], 'score': round(best['score'],2), 'issues': best['issues']})
+    return result

--- a/app/svc/pptx_template.py
+++ b/app/svc/pptx_template.py
@@ -1,0 +1,43 @@
+from pptx import Presentation
+from pptx.enum.shapes import PP_PLACEHOLDER
+from pathlib import Path
+from typing import Dict, Any, List
+
+
+def parse_template(path: Path) -> Dict[str, Any]:
+    prs = Presentation(path)
+    theme = getattr(prs.slide_master.part, 'theme', None)
+    theme_meta = {
+        'fonts': {
+            'title': getattr(getattr(theme, 'major_font', None), 'latin', None).typeface if theme else 'Calibri',
+            'body': getattr(getattr(theme, 'minor_font', None), 'latin', None).typeface if theme else 'Calibri',
+        },
+        'colors': {},
+        'page_size': {'w': prs.slide_width, 'h': prs.slide_height}
+    }
+    if theme:
+        color_scheme = getattr(theme, 'color_scheme', None)
+        for i in range(1,7):
+            if color_scheme:
+                color = getattr(color_scheme, f'accent{i}')
+                theme_meta['colors'][f'accent{i}'] = str(color.rgb)
+    layout_catalog: List[Dict[str, Any]] = []
+    for idx, layout in enumerate(prs.slide_layouts):
+        placeholders = {'title': False, 'bodies':0, 'pictures':0, 'table':False}
+        for shp in layout.placeholders:
+            ph_type = shp.placeholder_format.type
+            if ph_type == PP_PLACEHOLDER.TITLE:
+                placeholders['title'] = True
+            elif ph_type == PP_PLACEHOLDER.BODY:
+                placeholders['bodies'] += 1
+            elif ph_type == PP_PLACEHOLDER.PICTURE:
+                placeholders['pictures'] += 1
+            if shp.has_table:
+                placeholders['table'] = True
+        layout_catalog.append({
+            'layout_id': idx,
+            'name': layout.name,
+            'placeholders': placeholders,
+            'bbox': {}
+        })
+    return {'theme_meta': theme_meta, 'layout_catalog': layout_catalog}

--- a/app/svc/requirements.txt
+++ b/app/svc/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn[standard]
+python-pptx
+pdfplumber
+pdfminer.six
+pillow
+pytesseract
+pydantic
+numpy
+reportlab

--- a/app/svc/source_parser.py
+++ b/app/svc/source_parser.py
@@ -1,0 +1,58 @@
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+from pathlib import Path
+from typing import Dict, Any, List
+import pdfplumber
+
+
+def parse_pptx(path: Path) -> List[Dict[str, Any]]:
+    prs = Presentation(path)
+    slides = []
+    page_w, page_h = prs.slide_width, prs.slide_height
+    for idx, slide in enumerate(prs.slides):
+        title = False
+        bullets = 0
+        columns = 1
+        images = 0
+        table = False
+        text_boxes = []
+        for shp in slide.shapes:
+            if shp.has_text_frame:
+                text_boxes.append(shp)
+                for p in shp.text_frame.paragraphs:
+                    if p.level > 0 or p.text.strip().startswith(('•','-','–')):
+                        bullets += 1
+                if shp.top < page_h * 0.2:
+                    title = True
+            elif shp.shape_type == MSO_SHAPE_TYPE.PICTURE:
+                images += 1
+            if shp.has_table:
+                table = True
+        if len(text_boxes) >= 2:
+            centers = [tb.left + tb.width/2 for tb in text_boxes]
+            centers.sort()
+            if centers[-1] - centers[0] > page_w*0.25:
+                columns = 2
+        coverage = {'image':0,'text':0}
+        slide_area = page_w * page_h
+        for tb in text_boxes:
+            coverage['text'] += (tb.width*tb.height)/slide_area
+        for shp in slide.shapes:
+            if shp.shape_type == MSO_SHAPE_TYPE.PICTURE:
+                coverage['image'] += (shp.width*shp.height)/slide_area
+        slides.append({'idx': idx, 'signature': {'title': title, 'bullets': bullets, 'columns': columns, 'images': images, 'table': table, 'coverage': coverage}, 'warnings': []})
+    return slides
+
+
+def parse_pdf(path: Path) -> List[Dict[str, Any]]:
+    slides = []
+    with pdfplumber.open(path) as pdf:
+        for i, page in enumerate(pdf.pages):
+            text = page.extract_text() or ''
+            lines = text.splitlines()
+            title = bool(lines)
+            bullets = sum(1 for line in lines if line.strip().startswith(('•','-','–')))
+            images = len(page.images)
+            coverage = {'image':0,'text':0}
+            slides.append({'idx': i, 'signature': {'title': title, 'bullets': bullets, 'columns': 1, 'images': images, 'table': False, 'coverage': coverage}, 'warnings': []})
+    return slides

--- a/app/svc/tests/test_template.py
+++ b/app/svc/tests/test_template.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from pptx_template import parse_template
+from fixtures.generate import build_template, build_source_pptx
+from source_parser import parse_pptx
+from planner import plan_slides
+
+
+def test_template_parsing(tmp_path):
+    tpl_path = tmp_path / 'brand_simple.pptx'
+    build_template(tpl_path)
+    meta = parse_template(tpl_path)
+    assert 'layout_catalog' in meta
+    assert len(meta['layout_catalog']) >= 5
+
+
+def test_signature_extraction(tmp_path):
+    src_path = tmp_path / 'mini_5slide.pptx'
+    build_source_pptx(src_path)
+    slides = parse_pptx(src_path)
+    assert slides[1]['signature']['title'] is True
+    assert slides[1]['signature']['bullets'] >= 1
+
+
+def test_layout_matching(tmp_path):
+    tpl_path = tmp_path / 't.pptx'
+    build_template(tpl_path)
+    tpl = parse_template(tpl_path)
+    src_path = tmp_path / 's.pptx'
+    build_source_pptx(src_path)
+    slides = parse_pptx(src_path)
+    plan = plan_slides(slides, tpl)
+    assert len(plan) == len(slides)
+    assert all('chosen_layout_id' in s for s in plan)

--- a/app/web/Dockerfile
+++ b/app/web/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18
+WORKDIR /app
+COPY package.json package.json
+RUN npm install
+COPY . .
+CMD ["npm","run","dev"]

--- a/app/web/app/page.tsx
+++ b/app/web/app/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { useState } from 'react';
+import axios from 'axios';
+import { useDropzone } from 'react-dropzone';
+
+const api = axios.create({ baseURL: process.env.NEXT_PUBLIC_SVC_URL || 'http://localhost:8000' });
+
+export default function Home() {
+  const [templateId, setTemplateId] = useState<string|undefined>();
+  const [sourceId, setSourceId] = useState<string|undefined>();
+  const [plan, setPlan] = useState<any>();
+  const [jobId, setJobId] = useState<string|undefined>();
+
+  const onTemplateDrop = (files:File[])=>{
+    const form = new FormData();
+    form.append('template', files[0]);
+    api.post('/templates/ingest', form).then(r=>setTemplateId(r.data.template_id));
+  };
+  const onSourceDrop = (files:File[])=>{
+    if(!templateId) return;
+    const form = new FormData();
+    form.append('template_id', templateId);
+    form.append('source', files[0]);
+    api.post('/sources/ingest', form).then(r=>setSourceId(r.data.source_id));
+  };
+
+  const planCall = ()=>{
+    if(!templateId||!sourceId) return;
+    api.post('/transform/plan', {template_id:templateId, source_id:sourceId}).then(r=>setPlan(r.data));
+  };
+
+  const execute = ()=>{
+    if(!plan) return;
+    api.post('/transform/execute', {plan_id:plan.plan_id}).then(r=>setJobId(r.data.job_id));
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Deck Transformer</h1>
+      <section className="my-4">
+        <h2>1. Upload Template</h2>
+        <Dropzone onDrop={onTemplateDrop} disabled={!!templateId} />
+        {templateId && <p>Template ID: {templateId}</p>}
+      </section>
+      <section className="my-4">
+        <h2>2. Upload Source</h2>
+        <Dropzone onDrop={onSourceDrop} disabled={!templateId || !!sourceId} />
+        {sourceId && <p>Source ID: {sourceId}</p>}
+      </section>
+      <section className="my-4">
+        <button className="bg-blue-500 text-white px-4 py-2" onClick={planCall} disabled={!sourceId}>Plan</button>
+        {plan && <pre className="bg-gray-100 p-2 mt-2">{JSON.stringify(plan.slides, null, 2)}</pre>}
+      </section>
+      <section className="my-4">
+        <button className="bg-green-500 text-white px-4 py-2" onClick={execute} disabled={!plan}>Export</button>
+        {jobId && <p>Job ID: {jobId}</p>}
+      </section>
+    </div>
+  );
+}
+
+function Dropzone({onDrop, disabled}:{onDrop:(files:File[])=>void, disabled?:boolean}){
+  const {getRootProps, getInputProps, isDragActive} = useDropzone({onDrop: accepted=>onDrop(accepted)});
+  return (
+    <div {...getRootProps()} className={`border-dashed border p-4 text-center ${disabled?'opacity-50':''}`}>
+      <input {...getInputProps()} disabled={disabled}/>
+      {isDragActive ? <p>Drop files here...</p> : <p>Drag & drop file or click</p>}
+    </div>
+  );
+}

--- a/app/web/next-env.d.ts
+++ b/app/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "deck-transformer-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "axios": "1.6.8",
+    "react-dropzone": "14.2.3",
+    "zustand": "4.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.19",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "typescript": "5.3.3"
+  }
+}

--- a/app/web/tsconfig.json
+++ b/app/web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- build FastAPI service for deck template ingestion, source parsing, planning and execution
- add Next.js client for upload and export flow
- include fixtures, tests, and docker-compose infrastructure

## Testing
- `pip install -r app/svc/requirements.txt`
- `PYTHONPATH=app/svc pytest app/svc/tests/test_template.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8cce66024832596aff2f741f97d85